### PR TITLE
Fix samterm's view of the font height of Xft fonts

### DIFF
--- a/include/frame.h
+++ b/include/frame.h
@@ -27,6 +27,7 @@ struct Frame
 	short		left;		/* left edge of text */
 	ushort		nbox, nalloc;
 	ushort		maxtab;		/* max size of tab, in pixels */
+	ushort		fheight;	/* font height, in pixels */
 	ushort		nchars;		/* # runes in frame */
 	ushort		nlines;		/* # lines with text */
 	ushort		maxlines;	/* total # lines in frame */

--- a/libXg/menuhit.c
+++ b/libXg/menuhit.c
@@ -25,6 +25,11 @@ static	uchar menutxtbits[] = {
 	0x22, 0x22, 0x88, 0x88, 0x22, 0x22, 0x88, 0x88,
 };
 
+static int
+fontheight() {
+	return font->ascent + font->descent;
+}
+
 /*
  * r is a rectangle holding the text elements.
  * return the rectangle, including its black edge, holding element i.
@@ -34,8 +39,8 @@ menurect(Rectangle r, int i)
 {
 	if(i < 0)
 		return Rect(0, 0, 0, 0);
-	r.min.y += (font->height+Vspacing)*i;
-	r.max.y = r.min.y+font->height+Vspacing;
+	r.min.y += (fontheight()+Vspacing)*i;
+	r.max.y = r.min.y+fontheight()+Vspacing;
 	return inset(r, Border-Margin);
 }
 
@@ -48,7 +53,7 @@ menusel(Rectangle r, Point p)
 {
 	if(!ptinrect(p, r))
 		return -1;
-	return (p.y-r.min.y)/(font->height+Vspacing);
+	return (p.y-r.min.y)/(fontheight()+Vspacing);
 }
 
 /*
@@ -92,7 +97,7 @@ menupaint(Menu *menu, Rectangle textr, int off, int nitemdrawn)
 	r = inset(textr, Border-Margin);
 	bitblt(&screen, r.min, &screen, r, 0);
 	pt = Pt(textr.min.x+textr.max.x, textr.min.y);
-	for(i = 0; i<nitemdrawn; i++, pt.y += font->height+Vspacing){
+	for(i = 0; i<nitemdrawn; i++, pt.y += fontheight()+Vspacing){
 		item = menu->item? menu->item[i+off] : (*menu->gen)(i+off);
 		string(&screen,
 			Pt((pt.x-strwidth(font, item))/2, pt.y),
@@ -144,7 +149,7 @@ menuhit(int but, Mouse *m, Menu *menu)
 	}
 	if(menu->lasthit<0 || menu->lasthit>=nitem)
 		menu->lasthit = 0;
-	screenitem = (Dy(screen.r)-10)/(font->height+Vspacing);
+	screenitem = (Dy(screen.r)-10)/(fontheight()+Vspacing);
 	if(nitem>Maxunscroll || nitem>screenitem){
 		scrolling = 1;
 		nitemdrawn = Nscroll;
@@ -164,8 +169,8 @@ menuhit(int but, Mouse *m, Menu *menu)
 		off = 0;
 		lasti = menu->lasthit;
 	}
-	r = inset(Rect(0, 0, wid, nitemdrawn*(font->height+Vspacing)), -Margin);
-	r = rsubp(r, Pt(wid/2, lasti*(font->height+Vspacing)+font->height/2));
+	r = inset(Rect(0, 0, wid, nitemdrawn*(fontheight()+Vspacing)), -Margin);
+	r = rsubp(r, Pt(wid/2, lasti*(fontheight()+Vspacing)+fontheight()/2));
 	r = raddp(r, m->xy);
 	pt = Pt(0, 0);
 	if(r.max.x>screen.r.max.x)
@@ -180,7 +185,7 @@ menuhit(int but, Mouse *m, Menu *menu)
 	textr.max.x = menur.max.x-Margin;
 	textr.min.x = textr.max.x-maxwid;
 	textr.min.y = menur.min.y+Margin;
-	textr.max.y = textr.min.y + nitemdrawn*(font->height+Vspacing);
+	textr.max.y = textr.min.y + nitemdrawn*(fontheight()+Vspacing);
 	if(scrolling){
 		scrollr = inset(menur, Border);
 		scrollr.max.x = scrollr.min.x+Scrollwid;

--- a/libframe/frdelete.c
+++ b/libframe/frdelete.c
@@ -52,7 +52,7 @@ frdelete(Frame *f, ulong p0, ulong p1)
 			r.min = pt1;
 			r.max = pt1;
 			r.max.x += b->wid;
-			r.max.y += f->font->height;
+			r.max.y += f->fheight;
 			bitblt(f->b, pt0, f->b, r, S);
 			if(pt0.y == pt1.y)
 				r.min.x = r.max.x-(pt1.x-pt0.x);
@@ -72,9 +72,9 @@ frdelete(Frame *f, ulong p0, ulong p1)
 		if(n1 < f->nbox){
 			int q0, q1, q2;
 
-			q0 = pt0.y+f->font->height;
-			q1 = pt1.y+f->font->height;
-			q2 = pt2.y+f->font->height;
+			q0 = pt0.y+f->fheight;
+			q1 = pt1.y+f->fheight;
+			q2 = pt2.y+f->fheight;
 			bitblt(f->b, pt0, f->b, Rect(pt1.x, pt1.y, f->r.max.x, q1), S);
 			bitblt(f->b, Pt(f->r.min.x, q0), f->b, Rect(f->r.min.x, q1, f->r.max.x, q2), S);
 			frselectf(f, Pt(pt2.x, pt2.y-(pt1.y-pt0.y)), pt2, 0);
@@ -99,6 +99,6 @@ frdelete(Frame *f, ulong p0, ulong p1)
 	f->nchars -= p1-p0;
 	pt0 = frptofchar(f, f->nchars);
 	n = f->nlines;
-	f->nlines = (pt0.y-f->r.min.y)/f->font->height+(pt0.x>f->left);
+	f->nlines = (pt0.y-f->r.min.y)/f->fheight+(pt0.x>f->left);
 	return n - f->nlines;
 }

--- a/libframe/frdraw.c
+++ b/libframe/frdraw.c
@@ -22,7 +22,6 @@ _frdraw(Frame *f, Point pt)
 {
 	Frbox *b;
 	int nb, n;
-
 	for(b=f->box,nb=0; nb<f->nbox; nb++, b++){
 		_frcklinewrap0(f, &pt, b);
 		if(pt.y == f->r.max.y){
@@ -41,7 +40,7 @@ _frdraw(Frame *f, Point pt)
 			pt.x += b->wid;
 		}else{
 			if(b->a.b.bc == '\n')
-				pt.x = f->left, pt.y+=f->font->height;
+				pt.x = f->left, pt.y+=f->fheight;
 			else
 				pt.x += _frnewwid(f, pt, b);
 		}

--- a/libframe/frinit.c
+++ b/libframe/frinit.c
@@ -8,6 +8,9 @@ void
 frinit(Frame *f, Rectangle r, XftFont *ft, Bitmap *b)
 {
 	f->font = ft;
+	/* ft->height is NOT CORRECT; we must use ascent + descent to
+	   clear the lowest edge of characters. - cks */
+	f->fheight = ft->ascent + ft->descent;
 	f->maxtab = 8*charwidth(ft, '0');
 	f->nbox = 0;
 	f->nalloc = 0;
@@ -26,9 +29,9 @@ frsetrects(Frame *f, Rectangle r, Bitmap *b)
 	f->b = b;
 	f->entire = r;
 	f->r = r;
-	f->r.max.y -= (r.max.y-r.min.y)%f->font->height;
+	f->r.max.y -= (r.max.y-r.min.y)%f->fheight;
 	f->left = r.min.x+1;
-	f->maxlines = (r.max.y-r.min.y)/f->font->height;
+	f->maxlines = (r.max.y-r.min.y)/f->fheight;
 }
 
 void

--- a/libframe/frinsert.c
+++ b/libframe/frinsert.c
@@ -20,6 +20,7 @@ bxscan(Frame *f, Rune *sp, Rune *ep, Point *ppt)
 	frame.r = f->r;
 	frame.b = f->b;
 	frame.font = f->font;
+	frame.fheight = f->font->ascent + f->font->descent;
 	frame.maxtab = f->maxtab;
 	frame.left = f->left;
 	frame.nbox = 0;
@@ -169,14 +170,14 @@ frinsert(Frame *f, Rune *sp, Rune *ep, ulong p0)
 		_frdelbox(f, n0, f->nbox-1);
 	}
 	if(n0 == f->nbox)
-		f->nlines = (pt1.y-f->r.min.y)/f->font->height+(pt1.x>f->left);
+		f->nlines = (pt1.y-f->r.min.y)/f->fheight+(pt1.x>f->left);
 	else if(pt1.y!=pt0.y){
 		int q0, q1;
 
 		y = f->r.max.y;
-		q0 = pt0.y+f->font->height;
-		q1 = pt1.y+f->font->height;
-		f->nlines += (q1-q0)/f->font->height;
+		q0 = pt0.y+f->fheight;
+		q1 = pt1.y+f->fheight;
+		f->nlines += (q1-q0)/f->fheight;
 		if(f->nlines > f->maxlines)
 			chopframe(f, ppt1, p0, nn0);
 		if(pt1.y < y){
@@ -201,14 +202,14 @@ frinsert(Frame *f, Rune *sp, Rune *ep, ulong p0)
 			r.min = pts[npts].pt0;
 			r.max = r.min;
 			r.max.x += b->wid;
-			r.max.y += f->font->height;
+			r.max.y += f->fheight;
 			bitblt(f->b, pt, f->b, r, S);
 			if(pt.y < y){	/* clear bit hanging off right */
 				r.min = pt;
 				r.max = pt;
 				r.min.x += b->wid;
 				r.max.x = f->r.max.x;
-				r.max.y += f->font->height;
+				r.max.y += f->fheight;
 				bitblt(f->b, r.min, f->b, r, 0);
 			}
 			y = pt.y;
@@ -216,7 +217,7 @@ frinsert(Frame *f, Rune *sp, Rune *ep, ulong p0)
 			r.min = pt;
 			r.max = pt;
 			r.max.x += b->wid;
-			r.max.y += f->font->height;
+			r.max.y += f->fheight;
 			if(r.max.x >= f->r.max.x)
 				r.max.x = f->r.max.x;
 			bitblt(f->b, r.min, f->b, r, 0);

--- a/libframe/frptofchar.c
+++ b/libframe/frptofchar.c
@@ -57,7 +57,7 @@ Point
 _frgrid(Frame *f, Point p)
 {
 	p.y -= f->r.min.y;
-	p.y -= p.y%f->font->height;
+	p.y -= p.y%f->fheight;
 	p.y += f->r.min.y;
 	if(p.x > f->r.max.x)
 		p.x = f->r.max.x;

--- a/libframe/frselect.c
+++ b/libframe/frselect.c
@@ -57,9 +57,9 @@ frselectf(Frame *f, Point p0, Point p1, Fcode c)
 		p1.x = f->r.min.x;
 	q0 = p0;
 	q1 = p1;
-	q0.y += f->font->height;
-	q1.y += f->font->height;
-	n = (p1.y-p0.y)/f->font->height;
+	q0.y += f->fheight;
+	q1.y += f->fheight;
+	n = (p1.y-p0.y)/f->fheight;
 	if(f->b == 0)
 		berror("frselectf b==0");
 	if(p0.y == f->r.max.y)

--- a/libframe/frutil.c
+++ b/libframe/frutil.c
@@ -35,7 +35,7 @@ _frcklinewrap(Frame *f, Point *p, Frbox *b)
 {
 	if((b->nrune<0? b->a.b.minwid : b->wid) > f->r.max.x-p->x){
 		p->x = f->left;
-		p->y += f->font->height;
+		p->y += f->fheight;
 	}
 }
 
@@ -44,7 +44,7 @@ _frcklinewrap0(Frame *f, Point *p, Frbox *b)
 {
 	if(_frcanfit(f, *p, b) == 0){
 		p->x = f->left;
-		p->y += f->font->height;
+		p->y += f->fheight;
 	}
 }
 
@@ -53,7 +53,7 @@ _fradvance(Frame *f, Point *p, Frbox *b)
 {
 	if(b->nrune<0 && b->a.b.bc=='\n'){
 		p->x = f->left;
-		p->y += f->font->height;
+		p->y += f->fheight;
 	}else
 		p->x += b->wid;
 }

--- a/samterm/flayer.c
+++ b/samterm/flayer.c
@@ -334,9 +334,9 @@ flreshape(Rectangle dr)
 			r.min.x = dr.min.x;
 		if(r.max.x-r.min.x<100)
 			r.max.x = dr.max.x;
-		if(r.max.y-r.min.y<2*FLMARGIN+f->font->height)
+		if(r.max.y-r.min.y<2*FLMARGIN+f->fheight)
 			r.min.y = dr.min.y;
-		if(r.max.y-r.min.y<2*FLMARGIN+f->font->height)
+		if(r.max.y-r.min.y<2*FLMARGIN+f->fheight)
 			r.max.y = dr.max.y;
 		if(!move)
 			l->visible = None;

--- a/samterm/main.c
+++ b/samterm/main.c
@@ -385,7 +385,7 @@ onethird(Flayer *l, long a)
 		if(a > t->rasp.nrunes)
 			a = t->rasp.nrunes;
 		s = inset(l->scroll, 1);
-		lines = ((s.max.y-s.min.y)/l->f.font->height+1)/3;
+		lines = ((s.max.y-s.min.y)/l->f.fheight+1)/3;
 		if (lines < 2)
 			lines = 2;
 		outTsll(Torigin, t->tag, a, lines);

--- a/samterm/scroll.c
+++ b/samterm/scroll.c
@@ -129,7 +129,7 @@ scroll(Flayer *l, int pbut, int but)
 		scrflip(l, r);
 		p0 = 0;
 		if(but == 1)
-			p0 = (long)(my-s.min.y)/l->f.font->height+1;
+			p0 = (long)(my-s.min.y)/l->f.fheight+1;
 		else if(but == 2){
 			if(tot > 1024L*1024L)
 				p0 = ((tot>>10)*(y-s.min.y)/h)<<10;


### PR DESCRIPTION
Xft font info has a 'height' member that is not actually the font's
true height, which is actually (ascent + descent). Using plain 'height'
causes samterm to underpaint by a pixel in some fonts, resulting in
eg '_' characters getting overwritten. This fixes it by adding a new
frame field 'fheight' and using it instead of ->font->height.

libXg/menuhit.c needs special handling because it isn't passed the
frame, just the font. We introduce a new fontheight() function that
does the obvious and change the rest of the code to use this.