### PR TITLE
all: allow user to override build variables, and default CC to gcc

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -2,25 +2,25 @@
 # copyright 2015 Rob King <jking@deadpixi.com>
 
 # DESTDIR is the root of the installation tree
-DESTDIR=/usr/local
+DESTDIR?=/usr/local
 
 # BINDIR is the directory where binaries go
-BINDIR=$(DESTDIR)/bin
+BINDIR?=$(DESTDIR)/bin
 
 # MANDIR is where manual pages go
-MANDIR=$(DESTDIR)/share/man/man1
+MANDIR?=$(DESTDIR)/share/man/man1
 
 # USE64BITS should be 1 for little-endian architectures with 64-bit pointers,
 # 2 for big-endian architectures with 64-bit pointers, and 0 otherwisew.
 # x86_64 systems would generally use 1 here, while DEC Alpha systems would
 # generally use 2.
-USE64BITS=1
+USE64BITS?=1
 
 # FREETYPEINC should name the directory of your freetype2 includes.
-FREETYPEINC=/usr/include/freetype2
+FREETYPEINC?=/usr/include/freetype2
 
 # TMPDIR should be set to a directory for temporary files with lots of room
-TMPDIR=/tmp
+TMPDIR?=/tmp
 
 # If you want to have keyboard control of dot's position, set the following
 # variables to the appropriate ASCII control codes. The default values

--- a/libXg/Makefile
+++ b/libXg/Makefile
@@ -29,7 +29,7 @@ AR=ar
 LIB=libXg.a
 
 CFLAGS=$(OS) -D_LIBXG_EXTENSION $(INCS)
-CC=cc
+CC?=gcc
 
 OBJS=	arc.o arith.o balloc.o bitblt.o bitbltclip.o border.o bscreenrect.o\
 	circle.o clipline.o clipr.o copymasked.o cursorset.o cursorswitch.o\

--- a/libframe/Makefile
+++ b/libframe/Makefile
@@ -25,7 +25,7 @@ AR=ar
 CFLAGS=-c $(OS) $(INCS) -D_LIBXG_EXTENSION
 
 LIB=libframe.a
-CC=cc
+CC?=gcc
 
 OBJ=frbox.o frdelete.o frdraw.o frinit.o frinsert.o frptofchar.o\
 	frselect.o frstr.o frutil.o misc.o

--- a/sam/Makefile
+++ b/sam/Makefile
@@ -58,7 +58,7 @@ SYSFLAGS=  -DHOMEDIR=\"$(HOMEDIR)\" -DRSAMNAME=\"$(RSAMNAME)\" \
 		-DRXSAMNAME=\"$(RXSAMNAME)\" -DSAMSAVE=\"$(SAMSAVE)\"
 
 LIB=../libframe/libframe.a ../libXg/libXg.a
-CC=cc $(SYSFLAGS)
+CC?=gcc 
 
 OBJ=sam.o address.o buffer.o cmd.o disc.o error.o file.o io.o \
 	list.o mesg.o moveto.o multi.o rasp.o regexp.o shell.o \
@@ -67,7 +67,7 @@ OBJ=sam.o address.o buffer.o cmd.o disc.o error.o file.o io.o \
 all:    sam
 
 sam:	$(OBJ) $(LIB)
-	$(CC)  -o sam $(OBJ) $(LIB)
+	$(CC) $(SYSFLAGS) -o sam $(OBJ) $(LIB)
 
 clean:
 	rm -f *.o core sam

--- a/sam/Makefile
+++ b/sam/Makefile
@@ -49,9 +49,8 @@ RXSAMNAME=/usr/local/bin/rsam
 
 SAMSAVE=/bin/sh\\n$(SAMSAVEDIR)/samsave
 
-CFLAGS=$(OS) -D_LIBXG_EXTENSION $(INCS)
-
-SYSFLAGS=  -DHOMEDIR=\"$(HOMEDIR)\" -DRSAMNAME=\"$(RSAMNAME)\" \
+CFLAGS=$(OS) -D_LIBXG_EXTENSION $(INCS)\
+		-DHOMEDIR=\"$(HOMEDIR)\" -DRSAMNAME=\"$(RSAMNAME)\" \
 		-DTERMNAME=\"$(TERMNAME)\" -DTMP=\"$(TMP)\" \
 		-DSHELLNAME=\"$(SHELLNAME)\" -DSHELLPATH=\"$(SHELLPATH)\" \
 		-DRXNAME=\"$(RXNAME)\" -DRXPATHNAME=\"$(RXPATHNAME)\" \
@@ -67,7 +66,7 @@ OBJ=sam.o address.o buffer.o cmd.o disc.o error.o file.o io.o \
 all:    sam
 
 sam:	$(OBJ) $(LIB)
-	$(CC) $(SYSFLAGS) -o sam $(OBJ) $(LIB)
+	$(CC) -o sam $(OBJ) $(LIB)
 
 clean:
 	rm -f *.o core sam
@@ -86,4 +85,4 @@ cmd.o:	parse.h
 xec.o:	parse.h
 
 unix.o:	sam.h ../include/u.h ../include/libc.h errors.h mesg.h
-	$(CC) -c $(CFLAGS) $(SYSFLAGS) unix.c
+	$(CC) -c $(CFLAGS) unix.c

--- a/samterm/Makefile
+++ b/samterm/Makefile
@@ -31,7 +31,7 @@ XLIBS=-lXt -lX11 -lXft
 CFLAGS=$(OS) $(INCS) -D_LIBXG_EXTENSION -DLINEUP=$(LINEUP) -DLINEDOWN=$(LINEDOWN) -DCHARLEFT=$(CHARLEFT) -DCHARRIGHT=$(CHARRIGHT)
 
 LIBS=../libframe/libframe.a ../libXg/libXg.a
-CC=cc
+CC?=gcc
 
 OBJ=main.o flayer.o icons.o io.o menu.o mesg.o rasp.o scroll.o unix.o
 


### PR DESCRIPTION
This change allows the user to build an install this version of sam without changing config.mk.

Tested on Solaris11/sparc64 with gcc version 4.8.2.

    DESTDIR=/export/home/aram USE64BITS=2 CC="gcc -std=gnu99" make install