### PR TITLE
Makefiles: use LDFLAGS.

### DIFF
--- a/libXg/Makefile
+++ b/libXg/Makefile
@@ -41,7 +41,7 @@ OBJS=	arc.o arith.o balloc.o bitblt.o bitbltclip.o border.o bscreenrect.o\
 all install:	$(LIB)
 compile:	$(LIB)
 test:	$(LIB) test.o
-	$(CC) -o $@ $? $(LIB) $(XLIBS) -lm
+	$(CC) -o $@ $? $(LIB) $(XLIBS) -lm $(LDFLAGS)
 	echo try running test
 clean:
 	rm -f *.o test *.a

--- a/sam/Makefile
+++ b/sam/Makefile
@@ -66,7 +66,7 @@ OBJ=sam.o address.o buffer.o cmd.o disc.o error.o file.o io.o \
 all:    sam
 
 sam:	$(OBJ) $(LIB)
-	$(CC) -o sam $(OBJ) $(LIB)
+	$(CC) -o sam $(OBJ) $(LIB) $(LDFLAGS)
 
 clean:
 	rm -f *.o core sam

--- a/samterm/Makefile
+++ b/samterm/Makefile
@@ -38,7 +38,7 @@ OBJ=main.o flayer.o icons.o io.o menu.o mesg.o rasp.o scroll.o unix.o
 all:	samterm
 
 samterm:	$(OBJ) $(LIBS)
-	$(CC)  -o samterm $(OBJ) $(LIBS) $(XLIBS)
+	$(CC)  -o samterm $(OBJ) $(LIBS) $(XLIBS) $(LDFLAGS)
 
 clean:
 	rm -f *.o core samterm


### PR DESCRIPTION
Many Linux distributions use this default variables to tweak the linker (also the implicit Make rule overridden here).