### PR TITLE
doc/Makefile: add empty all target to not run install by default.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,6 +2,8 @@
 
 include ../config.mk
 
+all:
+
 install: sam.1 B
 	cp sam.1 "$(MANDIR)"
 	cp B "$(BINDIR)"


### PR DESCRIPTION
Currently a plain "make" run tries to install documentation.