### PR TITLE
Add A for Mod1Mask modmappings

### DIFF
--- a/samterm/samrc.c
+++ b/samterm/samrc.c
@@ -76,6 +76,7 @@ static Namemapping buttonmapping[] ={
 static Namemapping modmapping[] ={
     {"*", 0},
     {"c", ControlMask}, 
+    {"a", Mod1Mask},
     {"s", ShiftMask},
     {NULL, 0}
 };


### PR DESCRIPTION
This allows for using ALT as a modifier for key bindings.