### PR TITLE
optional autoindent

### DIFF
--- a/doc/samrc
+++ b/doc/samrc
@@ -67,3 +67,6 @@ background white:seashell:lightgreen:oldlace:lightcyan:gainsboro:lightyellow:min
 # Expand tabs and have tabstops every four columns
 tabs 4
 expandtabs true
+
+# Automatically indent lines
+autoindent true

--- a/doc/samrc.5
+++ b/doc/samrc.5
@@ -195,6 +195,23 @@ or
 If
 .Dq true ","
 then tabs will be automatically expanded.
+.It autoindent
+Determines whether a line following a non-empty indented line is automatically indented.
+It is of the form:
+.Bd -literal
+
+    autoindent B
+
+.Ed
+where
+.Em B
+is the string
+.Dq true
+or
+.Dq false "."
+If
+.Dq true ","
+then a new line after a non-empty indented line is automatically indented.
 .It snarfselection
 Indicates which X selection should be exchanged with
 .Nm

--- a/samterm/main.c
+++ b/samterm/main.c
@@ -391,43 +391,37 @@ ctlu(Rasp *r, int64_t o, int64_t p)
 int64_t
 indent(Flayer *l, long p)
 {
-	Text *t=(Text *)l->user1;
-	static wchar_t sbuf[7]={' ',' ',' ',' ',' ',' ',' '};
-	static wchar_t tbuf[7]={'\t','\t','\t','\t','\t','\t','\t'};
+	Text *t = (Text *)l->user1;
+	static wchar_t sbuf[7] = {' ',' ',' ',' ',' ',' ',' '};
+	static wchar_t tbuf[7] = {'\t','\t','\t','\t','\t','\t','\t'};
 	int i, is, it, q, c, space;
 
-	q = p-1; is = 0; it = 0; space=1;
-	for(;;) {
-		if(--q<l->origin) {
-			if(space) 
-				it = is = 0;
-			break;
-		}
+	q = p - 1; is = 0; it = 0; space = 1;
+	while(--q >= l->origin) {
 		c = raspc(&t->rasp, q);
-		if(c=='\n') {
-			if(space)
-				it = is = 0;
-			else
-				break;
-		} else if(c=='\t'){
+		if(c == '\n') {
+            break;
+		} else if(c == '\t') {
 			++it;
-		} else if(c==' '){
+		} else if(c == ' ') {
 			++is;
 		} else {
 			it = is = 0; 
 			space = 0;
 		}
 	}
+    if(space) 
+        it = is = 0;
 
-	while(it!=0) {
+	while(it != 0) {
 		i = it>7?7:it;
 		hgrow(t->tag, p, i, 0);
 		t->lock++;
 		hdatarune(t->tag, p, tbuf, i);
 		it -= i; p += i;
 	}
-	while(is!=0) {
-		i = is>7?7:is;
+	while(is != 0) {
+		i = is > 7? 7 : is;
 		hgrow(t->tag, p, i, 0);
 		t->lock++;
 		hdatarune(t->tag, p, sbuf, i);

--- a/samterm/main.c
+++ b/samterm/main.c
@@ -396,7 +396,7 @@ indent(Flayer *l, long p)
 	static wchar_t tbuf[7] = {'\t','\t','\t','\t','\t','\t','\t'};
 	int i, is, it, q, c, space;
 
-	q = p - 1; is = 0; it = 0; space = 1;
+	q = p - 1; is = 0; it = 0; space = true;
 	while(--q >= l->origin) {
 		c = raspc(&t->rasp, q);
 		if(c == '\n') {
@@ -407,7 +407,7 @@ indent(Flayer *l, long p)
 			++is;
 		} else {
 			it = is = 0; 
-			space = 0;
+			space = false;
 		}
 	}
     if(space) 

--- a/samterm/main.c
+++ b/samterm/main.c
@@ -27,6 +27,7 @@ bool    modified = false;       /* strange lookahead for menus */
 char    lock = 1;
 bool    hasunlocked = false;
 bool expandtabs = false;
+bool autoindent = false;
 char *machine = "localhost";
 int exfd = -1;
 const char *exname;
@@ -1023,7 +1024,7 @@ type(Flayer *l)    /* what a bloody mess this is -- but it's getting better! */
         l->p0 = a;
         l->p1 = a;
         typeend = a;
-        if (k.c == '\n' && t!=&cmd)
+        if (autoindent && k.c == '\n' && t!=&cmd)
             a = indent(l, a);
         if (k.c == '\n' || typeend - typestart > 100)
             flushtyping(false);

--- a/samterm/samrc.c
+++ b/samterm/samrc.c
@@ -11,8 +11,9 @@
 #include "flayer.h"
 #include "samterm.h"
 
-extern int expandtabs;
+extern bool expandtabs;
 extern int tabwidth;
+extern bool autoindent;
 
 typedef struct Namemapping Namemapping;
 struct Namemapping{
@@ -349,6 +350,16 @@ direxpandtabs(const char *s1, const char *s2, const char *s3, const char *s4, co
 }
 
 static int
+dirautoindent(const char *s1, const char *s2, const char *s3, const char *s4, const char *s5)
+{
+    if (strcasecmp(s1, "true") != 0 && strcasecmp(s1, "false") != 0)
+        return -1;
+
+    autoindent = (strcasecmp(s1, "true") == 0);
+    return 0;
+}
+
+static int
 dircomment(const char *s1, const char *s2, const char *s3, const char *s4, const char *s5)
 {
     return 0;
@@ -376,6 +387,7 @@ Directive directives[] ={
     {" font %1023[^\n]",                                          1,   dirfont},
     {" tabs %2[0-9]",                                             1,   dirtabs},
     {" expandtabs %99s",                                          1,   direxpandtabs},
+    {" autoindent %99s",                                          1,   dirautoindent},
     {" snarfselection %99s",                                      1,   dirsnarfselection},
     {" %1[#]",                                                    1,   dircomment},
     {" %1[^ ]",                                                   EOF, dircomment},


### PR DESCRIPTION
This patch implements autoindent. The implementation is non-aggressive: a new line immediately following an indented line is indented, however an empty line cancels the indentation. By default autoindent is off, and is controlled by an option in .samrc. 

I had a 'sticky' autoindent implementation in my version of sam (which I branched from SAM 4.3 years ago), but I think this milder version is more appropriate for a general feature. 

Just found this code base and thought I could contribute some of the features I privately introduced and used.