### PR TITLE
Add P command to print current filename

### DIFF
--- a/sam/cmd.c
+++ b/sam/cmd.c
@@ -24,6 +24,7 @@ struct cmdtab cmdtab[]={
     {'m',    0,  0,  1,  0,  aDot,   0,  0,  m_cmd},
     {'n',    0,  0,  0,  0,  aNo,    0,  0,  n_cmd},
     {'p',    0,  0,  0,  0,  aDot,   0,  0,  p_cmd},
+    {'P',    0,  0,  0,  0,  aNo,    0,  0,  P_cmd},
     {'q',    0,  0,  0,  0,  aNo,    0,  0,  q_cmd},
     {'r',    0,  0,  0,  0,  aDot,   0,  wordx,  e_cmd},
     {'s',    0,  1,  0,  0,  aDot,   1,  0,  s_cmd},

--- a/sam/parse.h
+++ b/sam/parse.h
@@ -60,7 +60,7 @@ bool D_cmd(File*, Cmd*), e_cmd(File*, Cmd*);
 bool f_cmd(File*, Cmd*), g_cmd(File*, Cmd*), i_cmd(File*, Cmd*);
 bool k_cmd(File*, Cmd*), m_cmd(File*, Cmd*), n_cmd(File*, Cmd*);
 bool p_cmd(File*, Cmd*), q_cmd(File*, Cmd*);
-bool P_cmd(File*, Cmd*), q_cmd(File*, Cmd*);
+bool P_cmd(File*, Cmd*), P_cmd(File*, Cmd*);
 bool s_cmd(File*, Cmd*), u_cmd(File*, Cmd*), w_cmd(File*, Cmd*);
 bool x_cmd(File*, Cmd*), X_cmd(File*, Cmd*), plan9_cmd(File*, Cmd*);
 bool eq_cmd(File*, Cmd*);

--- a/sam/parse.h
+++ b/sam/parse.h
@@ -60,6 +60,7 @@ bool D_cmd(File*, Cmd*), e_cmd(File*, Cmd*);
 bool f_cmd(File*, Cmd*), g_cmd(File*, Cmd*), i_cmd(File*, Cmd*);
 bool k_cmd(File*, Cmd*), m_cmd(File*, Cmd*), n_cmd(File*, Cmd*);
 bool p_cmd(File*, Cmd*), q_cmd(File*, Cmd*);
+bool P_cmd(File*, Cmd*), q_cmd(File*, Cmd*);
 bool s_cmd(File*, Cmd*), u_cmd(File*, Cmd*), w_cmd(File*, Cmd*);
 bool x_cmd(File*, Cmd*), X_cmd(File*, Cmd*), plan9_cmd(File*, Cmd*);
 bool eq_cmd(File*, Cmd*);

--- a/sam/xec.c
+++ b/sam/xec.c
@@ -185,6 +185,13 @@ p_cmd(File *f, Cmd *cp)
 }
 
 bool
+P_cmd(File *f, Cmd *cp)
+{
+	filename(f);
+	return true;
+}
+
+bool
 q_cmd(File *f, Cmd *cp)
 {
     trytoquit();


### PR DESCRIPTION
The P command prints the current file name. It enables a grep like command sequence while searching for code in a big file list. For example:

X/sam/ ,g/sel/ P
 -. /home/ckeen/src/tools/sam/sam/address.c
 -. /home/ckeen/src/tools/sam/sam/mesg.c
 -. /home/ckeen/src/tools/sam/sam/regexp.c
 +. /home/ckeen/src/tools/sam/sam/xec.c

I first thought of using F as the command name. IDK maybe I am missing something and the functionality can be achieved without extending the language?