### PR TITLE
center on last line of cmd window

### DIFF
--- a/samterm/main.c
+++ b/samterm/main.c
@@ -676,7 +676,7 @@ cmdjump(Flayer *l, int64_t a, Text *u, const char *arg)
         current(l);
         flushtyping(false);
         flsetselect(l, t->rasp.nrunes, t->rasp.nrunes);
-        center(l, a);
+        center(l, t->rasp.nrunes);
     }
 
     return a;


### PR DESCRIPTION
This fixes a bug in the jump command. Before this fix, when jumping, the command layer would center on the same line number you were working on in the previous layer. In other words, if you were on line 10 of a buffer when you jumped, the cmd layer would scroll to line 10 as well.

This fix makes the cmd layer center on the last line, where you can type a new command.