### PR TITLE
more precise selections for an I-beam cursor

### DIFF
--- a/libframe/frptofchar.c
+++ b/libframe/frptofchar.c
@@ -64,7 +64,7 @@ uint64_t
 frcharofpt(Frame *f, Point pt)
 {
     Point qt;
-    int w, bn;
+    int w, bn, cstart;
     uint8_t *s;
     Frbox *b;
     uint64_t p;
@@ -94,9 +94,13 @@ frcharofpt(Frame *f, Point pt)
                     if(r == 0)
                         berror("end of string in frcharofpt");
                     s += w;
+                    cstart = qt.x;
                     qt.x += charwidth(f->font, r);
-                    if(qt.x > pt.x)
+                    if(qt.x > pt.x){
+                        if(qt.x - pt.x < pt.x - cstart)
+                            p++;
                         break;
+                    }
                     p++;
                 }
             }


### PR DESCRIPTION
Earlier versions of sam always used an arrow-like cursor for selecting text, because the hitbox for selection was based on whole runes; click on a rune with the arrow to place the selection caret (set the dot) to the left of that rune.

Starting with 5b68048, this version uses an I-beam cursor, but retains the old hitbox model. This patch alters the hitbox by shifting it over 50%. This makes it easier to click between runes to place the caret; click between two runes to place the selection caret. If you miss and click on a rune, the selection will go to the side of the rune closest to your click point.

As a side effect, the hitbox for the leftmost rune is a little smaller now, but this is offset by the fact that clicking on the margin space by the scrollbar will place the caret as expected. I think the benefits of this patch (make clicking work like it does in other modern text editors) outweighs this side effect.

Tested with mono and proportional fonts.