### PR TITLE
samterm: correctly handle an exch with ourselves

### DIFF
--- a/libXg/GwinP.h
+++ b/libXg/GwinP.h
@@ -15,6 +15,7 @@ typedef struct {
     Charfunc    gotchar;    /* Notify app of char arrival */
     Mousefunc   gotmouse;   /* Notify app of mouse change */
     String      selection;  /* Current selection */
+    Boolean     selxfered;  /* Has selection been swapped. */
     int     compose;
 } GwinPart;
 

--- a/libXg/gwin.c
+++ b/libXg/gwin.c
@@ -461,6 +461,7 @@ SelCallback(Widget w, XtPointer cldata, Atom *sel, Atom *seltype,
     XTextProperty p = {0};
     char *ls[2] = {(char *)val, NULL};
 
+    gw->gwin.selxfered = true;
     if (*seltype == 0){
         if (gw->gwin.selection == NULL)
             gw->gwin.selection = strdup("");
@@ -515,14 +516,11 @@ SelectSwap(Widget w, String s)
     String ans;
 
     gw = (GwinWidget)w;
-    if(gw->gwin.selection){
-        XtFree(gw->gwin.selection);
-        gw->gwin.selection = NULL;
-    }
+    gw->gwin.selxfered = false;
     XtGetSelectionValue(w, XInternAtom(_dpy, clipatom, 0), XInternAtom(_dpy, "UTF8_STRING", 0), SelCallback, 0,
             XtLastTimestampProcessed(XtDisplay(w)));
 
-    while(gw->gwin.selection == NULL)
+    while(gw->gwin.selxfered == false)
         XtAppProcessEvent(XtWidgetToApplicationContext(w) , XtIMAll);
     ans = gw->gwin.selection;
     gw->gwin.selection = XtMalloc(strlen(s)+1);


### PR DESCRIPTION
Currently an exch operation is not reversible; if you accidentally
exch a selection, it can be pasted into another program but cannot be
exch'd back into sam. See Github issue #61 for a longer discussion. To
fix this bug we introduce an additional GwinPart field to explicitly
track whether the selection has been transferred instead of reusing
the selection buffer for this.

Fixes #61