### PR TITLE
Set dot correctly after applying the `<` command

### DIFF
--- a/sam/io.c
+++ b/sam/io.c
@@ -119,7 +119,7 @@ readio(File *f, bool *nulls, bool setdate)
     }
 
     errno = olderr;
-    return 1;
+    return nt;
 }
 
 void


### PR DESCRIPTION
Before that change dot was set to the first character of the imported text. This change corresponds to the behaviour of other sam versions in that the whole imported text is selected. This makes the `<` command more convenient to use.