### PR TITLE
Simplify symlink paths.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,10 +7,10 @@ all:
 install: sam.1 
 	mkdir -p "$(MANDIR)/man1"
 	cp sam.1 "$(MANDIR)/man1"
-	ln -sf "$(MANDIR)/man1/sam.1" "$(MANDIR)/man1/B.1"
-	ln -sf "$(MANDIR)/man1/sam.1" "$(MANDIR)/man1/samterm.1"
-	ln -sf "$(MANDIR)/man1/sam.1" "$(MANDIR)/man1/rsam.1"
-	ln -sf "$(MANDIR)/man1/sam.1" "$(MANDIR)/man1/sam.save.1"
+	ln -sf sam.1 "$(MANDIR)/man1/B.1"
+	ln -sf sam.1 "$(MANDIR)/man1/samterm.1"
+	ln -sf sam.1 "$(MANDIR)/man1/rsam.1"
+	ln -sf sam.1 "$(MANDIR)/man1/sam.save.1"
 	mkdir -p "$(MANDIR)/man5"
 	cp samrc.5 "$(MANDIR)/man5"
 


### PR DESCRIPTION
Since these are symlinks to a file in the same directory, there's no
need to include the full path. This saves some effort for packages,
since when DESTDIR is set to point to a staging dir, the symlink would
be to the staging dir rather than the final destination.