### PR TITLE
Trap a couple of signals in ssam in order to guarantee its temporary file is removed

### DIFF
--- a/ssam
+++ b/ssam
@@ -43,9 +43,9 @@ if [ -z "$TMPDIR" ]; then
 fi
 tmp="$TMPDIR/ssam.tmp.$USER.$$"
 
-cat "$@" >$tmp
+trap 'result=$?; rm -f "$tmp"; exit $result' INT EXIT KILL
+cat "$@" >"$tmp"
 
-input()
 {
     # select entire file
     echo ',{'
@@ -57,8 +57,6 @@ input()
     [ ! -z "$flagf" ] && cat "$flagf"
     [ ! -z "$flage" ] && echo "$flage"
     [ "$flagn" -eq 0 ] && echo ','
-}
+} | sam -d "$tmp" 2>/dev/null
 
-input | sam -d "$tmp" 2>/dev/null
-
-rm -f "$tmp"
+exit $?


### PR DESCRIPTION
The ssam script was recently introduced by commit 869369730a7757e34fdf45905cf97fa04ba2172b. This script is a bourne-variation of the ssam that is part of plan9ports. One issue that it has, however, is that a stray signal (or SIGINT) can interrupt the script before it terminates resulting in temporary file not being removed.

This PR fixes that by using bourne's `trap` to handle the signal and guarantee removal of the file. The SIGEXIT signal is also trapped so that we can drop the original way the temporary file was being removed.

The error code is preserved so that the original error code that is returned by `cat` will still be returned to the caller. As the `input()` function isn't really used for anything, this was also demoted to an anonymous function in order to more properly match the version from plan9ports. A potential but minor quoting issue for the output of `cat` was also fixed.

This should properly close request #104.