### PR TITLE
Fix build on 32-bit architectures

### DIFF
--- a/libXg/gwin.c
+++ b/libXg/gwin.c
@@ -455,7 +455,7 @@ Mouseaction(Widget w, XEvent *e, String *p, Cardinal *np)
 
 static void
 SelCallback(Widget w, XtPointer cldata, Atom *sel, Atom *seltype,
-    XtPointer val, uint64_t *len, int *fmt)
+    XtPointer val, unsigned long *len, int *fmt)
 {
     GwinWidget gw = (GwinWidget)w;
     XTextProperty p = {0};
@@ -486,7 +486,7 @@ SelCallback(Widget w, XtPointer cldata, Atom *sel, Atom *seltype,
 
 static Boolean
 SendSel(Widget w, Atom *sel, Atom *target, Atom *rtype, XtPointer *ans,
-        uint64_t *anslen, int *ansfmt)
+        unsigned long *anslen, int *ansfmt)
 {
     GwinWidget gw = (GwinWidget)w;
     XTextProperty p = {0};


### PR DESCRIPTION
Commit eab3ebc6 changed all occurrences of unsigned long to uint64_t, which does not work when it is used in callback functions whose signatures are defined with unsigned long by libXt. On 64-bit machines, unsigned long and uint64_t are the same type, but on 32-bit machines, long has only 32 bits. This makes the callback function pointer incompatible with the callback function parameter type.

The callback functions in question are the following (from X11/Intrinsic.h):

typedef Boolean (*XtConvertSelectionProc)(
    Widget 		/* widget */,
    Atom*		/* selection */,
    Atom*		/* target */,
    Atom*		/* type_return */,
    XtPointer*		/* value_return */,
    unsigned long*	/* length_return */,
    int*		/* format_return */
);
typedef Boolean (*XtConvertSelectionProc)(
    Widget 		/* widget */,
    Atom*		/* selection */,
    Atom*		/* target */,
    Atom*		/* type_return */,
    XtPointer*		/* value_return */,
    unsigned long*	/* length_return */,
    int*		/* format_return */
);

Both functions use pointers to unsigned long as output parameters for data length, so the functions implementing these callbacks have to use unsigned long, too.