### PR TITLE
fix a bunch of small errors in the man pages

### DIFF
--- a/doc/sam.1
+++ b/doc/sam.1
@@ -90,7 +90,7 @@ to represent newlines.
 A regular expression may never contain a literal newline character.
 The elements of regular expressions are:
 .Bl -tag -width Ds
-.It Li "."
+.It Li "\&."
 Match any character except newline.
 .It Li \[rs]n
 Match newline.
@@ -110,7 +110,7 @@ may be mentioned.
 Match any character not in the square brackets, but never a newline.
 Both this and the positive form above accept a range of ASCII characters indicated by a dash, as in
 .Li "a-z" "."
-.It Li "^"
+.It Li "\[ha]"
 Match the null string immediately after a newline.
 .It Li "$"
 Match the null string immediately before a newline.
@@ -149,9 +149,9 @@ The operators
 .Li "*" ","
 .Li "+" ","
 and
-.Li "?"
+.Li "\&?"
 are highest precedence, then catenation, then
-.Li "|"
+.Li "\&|"
 is lowest.
 The empty regular expression stands for the last complete expression encountered.
 A regular expression in
@@ -164,16 +164,16 @@ In the following
 .Do
 character
 .Sy n
-.Pc
+.Dc
 means the null string after the
-.Sy n\fR-th
+.Sy n Ns -th
 character in the file, with 1 the first character in the file.
 .Do
 Line
 .Sy n
 .Dc
 means the
-.Sy n\fR-th
+.Sy n Ns -th
 match, starting at the beginning of the file, of the regular expression
 .Li ".*\[rs]n?" "."
 .Po
@@ -193,11 +193,11 @@ is the beginning of the file.
 Line
 .Sy n "."
 .It Li / Sy regexp Li /
-.It Li ? Sy regexp Li ?
+.It Li \&? Sy regexp Li \&?
 The substring that matches the regular expression, found by looking toward the end
 .Pq Li /
 or beginning
-.Pq Li "?"
+.Pq Li "\&?"
 of the file, and if necessary continuing the search from the other end to the starting point of the search.
 The matched substring may straddle the starting point.
 When entering a pattern containing a literal question mark for a backward search, the question mark should be specified as a member of a class.
@@ -210,23 +210,23 @@ and
 below.
 .It Li $
 The null string at the end of the file.
-.It Li "."
+.It Li "\&."
 Dot.
-.It Li "'"
+.It Li "\[aq]"
 The mark in the file
 .Po
 see the
 .Sy k
 command below
 .Pc "."
-.It Do regexp Dc
+.It Li "\&""" Sy regexp Li "\&"""
 .Po
 A regular expression in double quotes.
 .Pc
 Preceding a simple address
 .Po
 default
-.Li "."
+.Li "\&."
 .Pc ","
 refers to the address evaluated in the unique file whose menu line matches the regular expression.
 .El
@@ -240,15 +240,15 @@ are addresses.
 .It Sy a1+a2
 The address
 .Sy a2
-evaulated starting at the end of
+evaluated starting at the end of
 .Sy a1 "."
-.It Sy a1-a2
+.It Sy a1\-a2
 The address
 .Sy a2
 evaluated looking the reverse direction starting at the beginning of
 .Sy a1 "."
 .It Sy "a1,a2"
-The substring from the beinning of
+The substring from the beginning of
 .Sy a1
 to the end of
 .Sy a2 "."
@@ -274,25 +274,25 @@ evaluated at the end of, and dot set to,
 The operators
 .Li +
 and
-.Li -
+.Li \-
 are high precedence, while
-.Li ,
+.Li \&,
 and
-.Li ;
+.Li \&;
 are low precedence.
 .Pp
 In both
 .Li +
 and
-.Li -
+.Li \-
 forms, if
 .Sy a2
 is a line or character address with a missing number, the number defaults to 1.
 If
 .Sy a1
 is missing,
-.Li "."
-is subtituted.
+.Li "\&."
+is substituted.
 If both
 .Sy a1
 and
@@ -302,20 +302,20 @@ are present and distinguishable,
 may be elided.
 .Sy a2
 may be a regular expression; if it is delimited by
-.Li ""?""
+.Li "\&?"
 characters, the effect of the
 .Li +
 or
-.Li -
+.Li \-
 is reversed.
 .Pp
 It is an error for a compound address to represent a malformed substring.
 .Pp
 Some useful idioms:
 .Bl -tag -width Ds
-.It Sy a1+- Po Sy a1-+ Pc
+.It Sy a1+\- Po Sy a1\-+ Pc
 selects the line containing the end
-.Dq beginning
+.Pq beginning
 of
 .Sy a1 "."
 .It Sy 0/regexp/
@@ -326,7 +326,7 @@ The form
 sets dot unnecessarily.
 .Pc
 .It Sy "./regexp///"
-find the second following occurence of the expression, and
+find the second following occurrence of the expression, and
 .Sy ".,/regexp/"
 extends dot.
 .El
@@ -358,7 +358,7 @@ is used to represent whatever address is supplied.
 Many commands set the value of dot as a side effect.
 If so, it is always to the
 .Dq result
-of the change: the empty string for a deletion, the new text for an insertion, etc.
+of the change: the empty string for a deletion, the new text for an insertion, etc.\&
 .Po
 but see the
 .Sy s
@@ -374,13 +374,13 @@ Set dot.
 .Pp
 May also be written as
 .Bd -literal -offset indent
- a
- lines
- of
- text
- .
+a
+lines
+of
+text
+\&.
 .Ed
-.It Sy c \fR or Sy i
+.It Sy c No or Sy i
 Same as
 .Sy a ","
 but
@@ -406,7 +406,7 @@ stands for the string that matched the expression.
 Backslash behaves as usual unless followed by a digit:
 .Sy \[rs]d
 stands for the string that matched the subexpression begun by the
-.Sy d\fR-th
+.Sy d Ns -th
 left parenthesis.
 If
 .Sy s
@@ -415,7 +415,7 @@ is followed immediately by a number
 as in
 .Li "s2/x/y/" ","
 the
-.Sy n\fR-th
+.Sy n Ns -th
 match in the range is substituted.
 If the command is followed by
 .Sy g ","
@@ -472,9 +472,9 @@ except that filenames not in the menu are entered there, and all file names in t
 Print a menu of files.
 The format is:
 .Bl -tag -width Ds
-.It "' or blank"
+.It "\[aq] or blank"
 indicating the file is modified or clean,
-.It "- or +"
+.It "\- or +"
 indicating the file is unread or has been read
 .Po
 in the terminal,
@@ -538,22 +538,23 @@ is used.
 In any of
 .Sy "<" ","
 .Sy ">" ","
-.Sy "|" ", or"
-.Sy "!" ","
+.Sy "\&|" ","
+or
+.Sy "\&!" ","
 if the shell command is omitted, the last shell command
 .Pq "of any type"
 is substituted.
 If
 .Nm
 is downloaded,
-.Sy "!"
+.Sy "\&!"
 sets standard input to
 .Pa "/dev/null" ","
 and otherwise unassigned output
 .Po
 .Pa stdout
 for
-.Sy "!"
+.Sy "\&!"
 and
 .Sy ">" ","
 .Pa stderr
@@ -647,7 +648,7 @@ is ineffective are
 and
 .Sy D "."
 .It Sy empty
-.Dq "The empty string as a command."
+.Pq "The empty string as a command."
 If the range is explicit, set dot to the range.
 If
 .Nm
@@ -655,7 +656,7 @@ is downloaded, the resulting dot is selected on the screen; otherwise it is prin
 If no address is specified
 .Pq "the command is a newline"
 dot is extended in either direction to the line boundaries and printed.
-If dot is thereby unchanged, i is set to
+If dot is thereby unchanged, it is set to
 .Li ".+1"
 and printed.
 .El
@@ -666,7 +667,7 @@ Commands within the braces must appear on separate lines
 .Do
 as those familiar with other editors might expect
 .Dc "."
-Semantically, the opening brance is like a command: it takes an
+Semantically, the opening brace is like a command: it takes an
 .Pq optional
 address and sets dot for each sub-command.
 Commands within the braces are executed sequentially, but changes made by one command are not visible to other commands
@@ -714,7 +715,7 @@ a null rectangle gets a large window disjoint from the command window or the who
 window, depending on where the null rectangle is.
 .It Sy zerox
 Create a copy of an existing window.
-After selecting the window to copy with button 1,
+After selecting the window to copy with button 3,
 sweep out the window for the copy.
 .It Sy reshape
 Change the size and location of a window.
@@ -737,19 +738,19 @@ for the file.
 .El
 .Pp
 Below these operators is a list of available files, starting with
-.Sy "~~sam~~" ","
+.Sy "\[ti]\[ti]sam\[ti]\[ti]" ","
 the command window.
 Selecting a file from the list makes the most recently used window on that file current, unless it is already current, in which case selections cycle through the open windows.
 If no windows are open on the file, the user is prompted to open one.
 Files other than
-.Sy "~~sam~~"
+.Sy "\[ti]\[ti]sam\[ti]\[ti]"
 are marked with one of the characters
-.Li "-+*"
+.Li "\-+*"
 according as zero, one, or more windows are open on the file.
 A further mark,
-.Li "." ","
+.Li "\&." ","
 appears on the file in the current window and a single quote,
-.Li "'" ","
+.Li "\[aq]" ","
 on a file modified since last write.
 .Pp
 The command window, created automatically when
@@ -758,7 +759,7 @@ starts, is an ordinary window except that text typed to it is interpreted as com
 There is an
 .Dq "output point"
 that separates commands being typed from previous output.
-Commands typed in the command window apply to the current open file\[en]the file in the most recently current window.
+Commands typed in the command window apply to the current open file\[em]the file in the most recently current window.
 .Ss Manipulating text
 Typed characters replace the current selection
 .Pq dot
@@ -778,7 +779,7 @@ Replace the text in dot by the contents of the snarf buffer.
 .It Sy snarf
 Save the text in dot in the snarf buffer.
 .It Sy look
-Search forward for the next occurence of the literal text in dot.
+Search forward for the next occurrence of the literal text in dot.
 If dot is the null string, the text in the snarf buffer is used.
 The snarf buffer is unaffected.
 .It Sy <exch>
@@ -795,7 +796,7 @@ Saves the sent text in the snarf buffer.
 .Pq "Command window only."
 .El
 .Pp
-The cut and paste operations can also be accessed  combinations of mouse buttons, without using the menu.
+The cut and paste operations can also be accessed using combinations of mouse buttons, without using the menu.
 After making a selection with button 1, pressing button 2 with button 1 still pressed will perform a cut operation.
 Pressing button 3 with button 1 still pressed will perform a paste operation.
 Performing both of these operations (pressing buttons 2 and then 3 with button 1 still pressed) is the equivalent of the snarf operation.
@@ -858,7 +859,7 @@ see
 .Pc "."
 The terminal's keybindings,
 mouse chords,
-tab handling, 
+tab handling,
 colors,
 and fonts may be set at runtime using these methods.
 .Ss Abnormal termination
@@ -869,7 +870,7 @@ terminates other than by a
 command
 .Pq "by hangup, deleting its window, etc." ","
 modified files are saved in an executable file,
-.Pq "${HOME}/sam.save" "."
+.Pa "${HOME}/sam.save" "."
 This program, when executed, asks whether to write each file back to an external file.
 The answer
 .Sy y
@@ -888,7 +889,7 @@ file, all changes are lost.
 If an editing session is difficult to replicate, writing changed files often is recommended.
 .Ss Remote execution
 .Nm sam
-allows the host and terminal parts of the editor to run on diffrent machines, in a process called
+allows the host and terminal parts of the editor to run on different machines, in a process called
 .Dq downloading "."
 This process can be suppressed with the
 .Fl d
@@ -914,7 +915,7 @@ command present on the remote system; invoking this command on the remote system
 .Po
 if
 .Nm sam
-was invoked with its default remote host command, i.e.
+was invoked with its default remote host command, i.e.\&
 .Nm sam
 .Pc
 open files in the local terminal.
@@ -952,11 +953,10 @@ For example, when using
 .Xr ssh 1
 as the remote shell mechanism,
 adding
-.Bd -literal
-
-    AcceptEnv LC_CTYPE
-
+.Bd -literal -offset indent
+AcceptEnv LC_CTYPE
 .Ed
+.Pp
 to
 .Xr ssh_config 5
 will allow the local character encoding specification to be exported to the remote system.
@@ -1010,8 +1010,8 @@ directive in
 .Xr samrc 5 "."
 .It Ev FONT
 A string representing a
-.Xr fc-match 1
-compatible font pattern.
+.Xr fc-match 1 Ns -compatible
+font pattern.
 The font described by this pattern will be used to render text in the terminal.
 By default, this is the string
 .Dq "monospace" "."
@@ -1026,11 +1026,10 @@ is invoked with the
 .Fl r
 option.
 It will be passed arguments of the form:
-.Bd -literal
-
-    -R REMOTE:LOCAL MACHINE COMMAND
-
+.Bd -literal -offset indent
+\-R REMOTE:LOCAL MACHINE COMMAND
 .Ed
+.Pp
 where
 .Em REMOTE
 is the name of the remote UNIX domain socket for remote control,
@@ -1041,7 +1040,7 @@ is the hostname to connect to, and
 .Em COMMAND
 is the command
 .Po
-e.g.
+e.g.\&
 .Nm sam
 .Pc
 to execute on that machine.
@@ -1078,7 +1077,9 @@ Names a directory in which
 remote control sockets should be placed on remote systems.
 .It Ev TABS
 A number between 1 and 12, indicating the width of a tab character.
-This number is treated as a multiplier of the width of the '0' character.
+This number is treated as a multiplier of the width of the
+.Sq 0
+character.
 The default is 8.
 .Pp
 If the number specified for
@@ -1112,10 +1113,9 @@ Stores output of shell commands executed by
 .Nm "."
 .El
 .Sh SEE ALSO
-.Xr ed 1
+.Xr ed 1 ,
 .Xr samrc 5
 .Sh BUGS
-.Pp
 The only human language in which colors may be specified is English.
 .Pp
 The only human language in which output is generated is English.

--- a/doc/samrc.5
+++ b/doc/samrc.5
@@ -5,7 +5,7 @@
 .Nm samrc
 .Nd configure samterm
 .Sh SYNOPSIS
-.Pa ~/.samrc
+.Pa \[ti]/.samrc
 .Sh DESCRIPTION
 A
 .Nm
@@ -23,17 +23,16 @@ Lines whose first printing character is a
 .Dq "#"
 are considered comments and are ignored.
 The following configuration directives are supported:
-.Bl -tag
+.Bl -tag -width Ds
 .It bind
 Bind a key sequence to a command or a raw character.
 The forms are:
-.Bd -literal
-
-    bind M K command C A
-    bind M K command C
-    bind M K raw C
-
+.Bd -literal -offset indent
+bind M K command C A
+bind M K command C
+bind M K raw C
 .Ed
+.Pp
 Where
 .Em M
 is a string describing a set of modifier keys
@@ -63,11 +62,10 @@ and that not all commands will make use of arguments.
 .It unbind
 Remove all bindings associated with a key sequence.
 The form is:
-.Bd -literal
-
-    unbind M K
-
+.Bd -literal -offset indent
+unbind M K
 .Ed
+.Pp
 where
 .Em M
 is a string describing a set of modifier keys and
@@ -80,11 +78,10 @@ The key sequence may be subsequently rebound.
 .It chord
 Bind a mouse chord to a command.
 The form is:
-.Bd -literal
-
-    chord S1 S2 C T
-
+.Bd -literal -offset indent
+chord S1 S2 C T
 .Ed
+.Pp
 where
 .Em S1
 is a string describing the initial state of the mouse buttons
@@ -108,11 +105,10 @@ below
 .It unchord
 Remove all bindings for a given mouse chord.
 The form is:
-.Bd -literal
-
-    unchord S1 S2
-
+.Bd -literal -offset indent
+unchord S1 S2
 .Ed
+.Pp
 where
 .Em S1
 and
@@ -122,11 +118,10 @@ The chord may be subsequently rebound.
 .It foreground
 Names the color used to draw text.
 It is of the form:
-.Bd -literal
-
-    foreground C
-
+.Bd -literal -offset indent
+foreground C
 .Ed
+.Pp
 where
 .Em C
 is a color name suitable for passing to
@@ -134,11 +129,10 @@ is a color name suitable for passing to
 .It background
 Names the color used to draw the background of files being edited.
 It is of the form:
-.Bd -literal
-
-    background C
-
+.Bd -literal -offset indent
+background C
 .Ed
+.Pp
 where
 .Em C
 is a colon-separated list of color names as for the foreground directive.
@@ -147,46 +141,44 @@ files will cycle through these background colors.
 .It border
 Names the color used to draw file borders.
 It is of the form:
-.Bd -literal
-
-    border C
-
+.Bd -literal -offset indent
+border C
 .Ed
+.Pp
 where
 .Em C
 is a color specification as for foreground.
 .It font
 Specifies the font used to draw text.
 It is of the form:
-.Bd -literal
-
-    font F
-
+.Bd -literal -offset indent
+font F
 .Ed
+.Pp
 where
 .Em F
 is an
-.Xr fc-match 1
-compatible font pattern.
+.Xr fc-match 1 Ns -compatible
+font pattern.
 .It tabs
-Specifies the width of tab characters in multiples of the width of the '0' character.
+Specifies the width of tab characters in multiples of the width of the
+.Sq 0
+character.
 It is of the form:
-.Bd -literal
-
-    tabs N
-
+.Bd -literal -offset indent
+tabs N
 .Ed
+.Pp
 where
 .Em N
 is an integer between 1 and 12.
 .It expandtabs
 Determines if tabs should be automatically expanded into spaces.
 It is of the form:
-.Bd -literal
-
-    expandtabs B
-
+.Bd -literal -offset indent
+expandtabs B
 .Ed
+.Pp
 where
 .Em B
 is the string
@@ -199,11 +191,10 @@ then tabs will be automatically expanded.
 .It autoindent
 Determines whether a line following a non-empty indented line is automatically indented.
 It is of the form:
-.Bd -literal
-
-    autoindent B
-
+.Bd -literal -offset indent
+autoindent B
 .Ed
+.Pp
 where
 .Em B
 is the string
@@ -215,26 +206,24 @@ If
 then a new line after a non-empty indented line is automatically indented.
 .It snarfselection
 Indicates which X selection should be exchanged with
-.Nm
+.Nm sam
 upon execution of the
 .Em exchange
 command
 .Pq "either via the menu item or key binding" "."
 The forms are:
-.Bd -literal
-
-    snarfselection primary
-    snarfselection secondary
-    snarfselection clipboard
+.Bd -literal -offset indent
+snarfselection primary
+snarfselection secondary
+snarfselection clipboard
 .Ed
 .It followfocus
 Determines window focus mode.
 It is of the form:
-.Bd -literal
-
-    followfocus B
-
+.Bd -literal -offset indent
+followfocus B
 .Ed
+.Pp
 where
 .Em B
 is the string
@@ -256,7 +245,9 @@ and tabstops are set at every eight characters.
 The default X selection is
 .Do primary
 .Dc "."
-The default window focus mode is "Click to focus". Typing is directed to the window which was last clicked.
+The default window focus mode is
+.Dq "Click to focus" "."
+Typing is directed to the window which was last clicked.
 .Ss "Modifier Keys"
 The
 .Em bind
@@ -273,13 +264,13 @@ meaning Control, or
 meaning Shift.
 .Pp
 For example,
-bind the "exchange" command to
+to bind the
+.Dq exchange
+command to
 .Em Control-Shift-E ","
 the following directive could be used:
-.Bd -literal
-
-    bind CS e command exchange
-
+.Bd -literal -offset indent
+bind CS e command exchange
 .Ed
 .Ss "Command Names"
 The following names can be used for commands:
@@ -331,14 +322,13 @@ the text to send is specified in the argument of the binding.
 For example, to bind
 .Em Control-Z
 to undo the last 10 changes, the following line binding could be used:
-.Bd -literal
-
-    bind C z command send u10
-
+.Bd -literal -offset indent
+bind C z command send u10
 .Ed
+.Pp
 Note that the
 .Dq send
-command is analagous to the
+command is analogous to the
 .Dq send
 menu item:
 the argument text is simply appended to the text in the command window.
@@ -355,32 +345,33 @@ corresponding to the buttons on the mouse numbered from the left
 .Pq "though this is up to your windowing system and may vary" "."
 For example,
 the string
-.Bd -literal
-
-    12
-
+.Bd -literal -offset indent
+12
 .Ed
+.Pp
 means
-.Dq "buttons 1 and 2 are pressed".
+.Dq "buttons 1 and 2 are pressed" "."
 The special string
 .Dq "n"
 means
-.Dq "no buttons are pressed".
+.Dq "no buttons are pressed" "."
 Thus to bind the
 .Em cut
 command to the chord
 .Dq "hold button one, then click button two"
 the following configuration directive can be used:
-.Bd -literal
-
-    chord 1 12 cut current
-
+.Bd -literal -offset indent
+chord 1 12 cut current
 .Ed
 .Ss "Targets"
 Mouse chords can send their commands to either the current file
 .Pq "i.e. the one receiving typed input"
-by specifying "current" as the target;
-or to the file under the mouse pointer by specifying "mouse" as the target.
+by specifying
+.Dq current
+as the target;
+or to the file under the mouse pointer by specifying
+.Dq mouse
+as the target.
 .Ss Ordering considerations
 Commands are executed in the order they are present in the
 .Nm


### PR DESCRIPTION
They are mostly formatting errors, such as unescaped punctuation that isn't meant to be interpreted as punctuation.

There is more that could be improved, but these changes should be the least opinion-based ones.

On many systems, some of these changes don’t usually result in different output. You can use ``groff -Tpdf -mdoc sam.1`` to get a PDF; some things might be more easily visible there.