### PR TITLE
Don't remove socket when exiting forked process

### DIFF
--- a/sam/io.c
+++ b/sam/io.c
@@ -269,9 +269,13 @@ connectto(char *machine)
     close(p2[0]);
 }
 
+bool forked;
+
 void
 removesocket(void)
 {
+    if (forked)
+        return;
     close(exfd);
     unlink(exname);
     exname[0] = 0;
@@ -348,6 +352,7 @@ startup(char *machine, bool rflag, bool trylock)
     if (!rflag)
         bootterm(machine);
 
+    forked = false;
     downloaded = true;
     outTs(Hversion, VERSION);
 }

--- a/sam/sam.c
+++ b/sam/sam.c
@@ -154,7 +154,7 @@ bmain(int argc, char *argv[])
 void
 rmsocket(void)
 {
-    if (rmsocketname)
+    if (rmsocketname && !forked)
         unlink(rmsocketname);
 }
 

--- a/sam/sam.h
+++ b/sam/sam.h
@@ -322,6 +322,7 @@ extern String   plan9cmd;
 extern bool  downloaded;
 extern bool  eof;
 extern bool  bpipeok;
+extern bool  forked;
 extern bool  panicking;
 extern wchar_t empty[];
 extern int  termlocked;

--- a/sam/shell.c
+++ b/sam/shell.c
@@ -5,6 +5,7 @@
 #include <limits.h>
 
 extern  jmp_buf mainloop;
+extern  bool forked;
 
 char    errfile[PATH_MAX + 1];
 String  plan9cmd;   /* null terminated */
@@ -35,6 +36,7 @@ plan9(File *f, int type, String *s, int nest)
     if(downloaded)
         remove(errfile);
     if((pid=fork()) == 0){
+        forked = true;
         if(downloaded){ /* also put nasty fd's into errfile */
             fd = creat(errfile, 0600L);
             if(fd < 0)


### PR DESCRIPTION
Previously, using any command that forked sam would run the odd risk of causing sam's control socket to exit. This seems to be a consequence of using atexit() to schedule removal of the control socket from the file system.

This commit adds a global boolean named forked, which is set to true in child process after they are forked. The exit handlers removesocket() and rmsocket() are changed such that they don't remove the control sockets if the forked boolean is set to true.

Sam's control socket should only get removed once the main instance exits.

Fixes #75